### PR TITLE
fix: fix login_auth_fail

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,8 @@ from datetime import datetime
 from argparse import ArgumentParser
 
 TIME = datetime.today().strftime('%Y-%m-%d')
-USERAGENT = "Mozilla/5.0 (Linux; Android 5.0; SM-N9100 Build/LRX21V) > AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 > Chrome/37.0.0.0 Mobile Safari/537.36 > MicroMessenger/6.0.2.56_r958800.520 NetType/WIFI"
+USERAGENT = "Mozilla/5.0 (Linux; Android 5.0; SM-N9100 Build/LRX21V) > AppleWebKit/537.36 (KHTML, like Gecko) " \
+            "Version/4.0 > Chrome/37.0.0.0 Mobile Safari/537.36 > MicroMessenger/6.0.2.56_r958800.520 NetType/WIFI "
 PROCESS = ["-------日志-------"]
 
 USERNAME = ""  # 学号
@@ -25,18 +26,18 @@ class ReportException(Exception):
     """上报异常错误信息"""
 
 
-# 获取JESSIONID
-def getJESSIONID():
+# 获取JSESSIONID
+def getJSESSIONID():
     header = {
         'User-Agent': USERAGENT,
     }
-    Url = "http://xy.4009955.com/sfrzwx/auth/login"
+    url = "http://xy.4009955.com/sfrzwx/auth/login"
     data = {
         "openid": OPENID,
         "dlfs": "zhmm"
     }
-    responseRes = requests.get(Url, data=data, headers=header)
-    jid = responseRes.headers['Set-Cookie'].split(';')[0]
+    response_res = requests.get(url, data=data, headers=header)
+    jid = requests.utils.dict_from_cookiejar(response_res.cookies)['JSESSIONID']
     print('jid')
     PROCESS.append(jid)
     return jid
@@ -46,11 +47,13 @@ def getJESSIONID():
 def getYzm(jid):
     header = {
         'User-Agent': USERAGENT,
-        'cookie': jid
     }
-    postUrl = "http://xy.4009955.com/sfrzwx/wxsq/getYzm"
-    responseRes = requests.post(postUrl, headers=header)
-    base64code = responseRes.content.decode().split('"')[7].split(',')[1]
+    cookie = {
+        "JSESSIONID": jid
+    }
+    post_url = "http://xy.4009955.com/sfrzwx/wxsq/getYzm"
+    response_res = requests.post(post_url, headers=header, cookies=cookie)
+    base64code = response_res.json()['data']['content'].split(',')[1]
     imagedata = base64.b64decode(base64code)
     ocr = ddddocr.DdddOcr()
     yzm = ocr.classification(imagedata)
@@ -64,9 +67,11 @@ def getYzm(jid):
 def login(jid, yzm):
     header = {
         'User-Agent': USERAGENT,
-        "cookie": jid
     }
-    postUrl = "http://xy.4009955.com/sfrzwx/wx/login"
+    cookie = {
+        "JSESSIONID": jid
+    }
+    post_url = "http://xy.4009955.com/sfrzwx/wx/login"
     data = {
         "openid": OPENID,
         "dlfs": "zhmm",
@@ -78,18 +83,20 @@ def login(jid, yzm):
         "password": PASSWORD,
         "code": yzm
     }
-    requests.post(postUrl, data=data, headers=header)
+    requests.post(post_url, data=data, headers=header, cookies=cookie)
 
 
 # 获取code,code会用来获取微信服务大厅token
 def getCode1(jid):
     header = {
         'User-Agent': USERAGENT,
-        "cookie": jid
     }
-    Url = "http://xy.4009955.com/sfrzwx/oauth/authorize?response_type=code&scope=read&client_id=wxfwdt&redirect_uri=http://xy.4009955.com/wxfwdt/&state=tysfrz"
-    responseRes = requests.get(Url, headers=header, allow_redirects=False)
-    code = responseRes.headers['Location'].split('?')[1].split('=')[1].split('&')[0]
+    cookie = {
+        "JSESSIONID": jid
+    }
+    url = "http://xy.4009955.com/sfrzwx/oauth/authorize?response_type=code&scope=read&client_id=wxfwdt&redirect_uri=http://xy.4009955.com/wxfwdt/&state=tysfrz"
+    response_res = requests.get(url, headers=header, cookies=cookie, allow_redirects=False)
+    code = response_res.headers['Location'].split('?')[1].split('=')[1].split('&')[0]
     x = "code1:" + code
     print('code1')
     PROCESS.append(x)
@@ -100,28 +107,32 @@ def getCode1(jid):
 def getWxfwdttoken(jid, code):
     header = {
         'User-Agent': USERAGENT,
-        "cookie": jid
+    }
+    cookie = {
+        "JSESSIONID": jid
     }
     data = {
         "code": code
     }
-    postUrl = "http://xy.4009955.com/wxfwdt-api/layout_01_01/login/loginYdBycode"
-    responseRes = requests.post(postUrl, json=data, headers=header)
-    # print(responseRes.content.decode().split('"'))
-    x = "wxtoken:" + responseRes.content.decode().split('"')[21]
-    print('wxtoken')
+    post_url = "http://xy.4009955.com/wxfwdt-api/layout_01_01/login/loginYdBycode"
+    response_res = requests.post(post_url, json=data, headers=header, cookies=cookie)
+    wxfwdttoken = response_res.json()['data']['content']['token']
+    x = "wxtoken:" + wxfwdttoken
     PROCESS.append(x)
-    return responseRes.content.decode().split('"')[21]
+    return wxfwdttoken
 
 
 def getCode2(jid, wxtoken):
     header = {
         'User-Agent': USERAGENT,
-        "cookie": f"{jid};wxfwdtToken={wxtoken}"
     }
-    postUrl = "http://xy.4009955.com/sfrzwx/oauth/authorize?response_type=code&scope=read&client_id=jktb&redirect_uri=http://xy.4009955.com/jktb/&state=tysfrz"
-    responseRes = requests.get(postUrl, headers=header, allow_redirects=False)
-    code = responseRes.headers['Location'].split('?')[1].split('=')[1].split('&')[0]
+    cookie = {
+        "JSESSIONID": jid,
+        "wxfwdtToken": wxtoken
+    }
+    post_url = "http://xy.4009955.com/sfrzwx/oauth/authorize?response_type=code&scope=read&client_id=jktb&redirect_uri=http://xy.4009955.com/jktb/&state=tysfrz"
+    response_res = requests.get(post_url, headers=header, cookies=cookie, allow_redirects=False)
+    code = response_res.headers['Location'].split('?')[1].split('=')[1].split('&')[0]
     x = "code2:" + code
     print('code2')
     PROCESS.append(x)
@@ -131,37 +142,48 @@ def getCode2(jid, wxtoken):
 def getJktbtoken(jid, wxtoken, code):
     header = {
         'User-Agent': USERAGENT,
-        "cookie": f"{jid};wxfwdtToken={wxtoken}"
+    }
+    cookie = {
+        "JSESSIONID": jid,
+        "wxfwdtToken": wxtoken
     }
     data = {
         "code": code
     }
-    postUrl = "http://xy.4009955.com/jktb-api/jktb_01_01/login/loginYdBycode"
-    responseRes = requests.post(postUrl, json=data, headers=header)
-    # print(responseRes.content.decode().split('"'))
-    x = "jktoken:" + responseRes.content.decode().split('"')[21]
+    post_url = "http://xy.4009955.com/jktb-api/jktb_01_01/login/loginYdBycode"
+    response_res = requests.post(post_url, json=data, headers=header, cookies=cookie)
+    jtkbtoken = response_res.json()['data']['content']['token']
+    x = "jktoken:" + jtkbtoken
     print('jktoken')
     PROCESS.append(x)
-    return responseRes.content.decode().split('"')[21]
+    return jtkbtoken
 
 
 def getTodayForms(jid, wxtoken, jktoken):
     header = {
         'User-Agent': USERAGENT,
-        "cookie": f"{jid};wxfwdtToken={wxtoken};jktb_token={jktoken}"
     }
-    postUrl = "http://xy.4009955.com/jktb-api/jktb_01_01/homePage/getToadyForms"
-    responseRes = requests.post(postUrl, headers=header)
-    x = "todayid:" + responseRes.content.decode().split('"')[17]
+    cookie = {
+        "JSESSIONID": jid,
+        "wxfwdtToken": wxtoken,
+        "jktb_token": jktoken
+    }
+    post_url = "http://xy.4009955.com/jktb-api/jktb_01_01/homePage/getToadyForms"
+    response_res = requests.post(post_url, headers=header, cookies=cookie)
+    form = response_res.json()['data']['content'][0]['bdtbslid']
+    x = "todayid:" + form
     print('todayid')
     PROCESS.append(x)
-    return responseRes.content.decode().split('"')[17]
+    return form
 
 
 def submit(jid, jktoken, todayid):
     header = {
         'User-Agent': USERAGENT,
-        "cookie": f"{jid};jktb_token={jktoken}"
+    }
+    cookie = {
+        "JSESSIONID": jid,
+        "jktb_token": jktoken
     }
     data = {"list": [
         {"zjlx": 3, "list": [{"column": "c001", "content": "校内"}, {"column": "c002", "content": "校外"}],
@@ -212,9 +234,9 @@ def submit(jid, jktoken, todayid):
         "tbrq": TIME, "mrtbjzsj": "22:10", "xm": XM, "zzjgmc": XUEYUAN,
         "bdtbslid": todayid, "bdmc": "学生每日健康填报"}
 
-    postUrl = "http://xy.4009955.com/jktb-api/jktb_01_01/homePage/saveForm"
-    responseRes = requests.post(postUrl, json=data, headers=header)
-    x = "finalRes:" + responseRes.content.decode()
+    post_url = "http://xy.4009955.com/jktb-api/jktb_01_01/homePage/saveForm"
+    response_res = requests.post(post_url, json=data, headers=header, cookies=cookie)
+    x = "finalRes:" + response_res.content.decode()
     print(x)
     PROCESS.append(x)
 
@@ -222,7 +244,7 @@ def submit(jid, jktoken, todayid):
 def tianbao():
     for _ in range(5):
         try:
-            jid = getJESSIONID()
+            jid = getJSESSIONID()
             yzm = getYzm(jid)
             login(jid, yzm)
             wxcode = getCode1(jid)


### PR DESCRIPTION
When I used the script to fill in my daily report, I found that it didn't work. So I downloaded it to debug locally and found that the token I got when getting the WeChat token using split() was my phone number, so I rewrote the part that gets the parameters using the more formal json() method and now it works fine.

- Use json instead of split string
- Use cookie instead of string splice